### PR TITLE
Support for image families in the Auther

### DIFF
--- a/contracts/AttestationAutherSample.sol
+++ b/contracts/AttestationAutherSample.sol
@@ -87,6 +87,13 @@ contract AttestationAutherSample is
         return _revokeEnclaveKey(enclavePubKey);
     }
 
+    function addEnclaveImageToFamily(
+        bytes32 imageId,
+        bytes32 family
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        return _addEnclaveImageToFamily(imageId, family);
+    }
+
     //-------------------------------- Admin methods end --------------------------------//
 
     //-------------------------------- Open methods start -------------------------------//

--- a/contracts/AttestationAutherSample.sol
+++ b/contracts/AttestationAutherSample.sol
@@ -94,6 +94,13 @@ contract AttestationAutherSample is
         return _addEnclaveImageToFamily(imageId, family);
     }
 
+    function removeEnclaveImageFromFamily(
+        bytes32 imageId,
+        bytes32 family
+    ) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        return _removeEnclaveImageFromFamily(imageId, family);
+    }
+
     //-------------------------------- Admin methods end --------------------------------//
 
     //-------------------------------- Open methods start -------------------------------//

--- a/contracts/AttestationAutherSample.sol
+++ b/contracts/AttestationAutherSample.sol
@@ -128,5 +128,14 @@ contract AttestationAutherSample is
         _allowOnlyVerified(signer);
     }
 
+    function verifyFamily(bytes memory signature, string memory message, bytes32 family) external view {
+        bytes32 hashStruct = keccak256(abi.encode(MESSAGE_TYPEHASH, keccak256(bytes(message))));
+        bytes32 digest = keccak256(abi.encodePacked("\x19\x01", DOMAIN_SEPARATOR, hashStruct));
+
+        address signer = ECDSA.recover(digest, signature);
+
+        _allowOnlyVerifiedFamily(signer, family);
+    }
+
     //-------------------------------- Open methods end -------------------------------//
 }

--- a/contracts/AttestationAutherSample.sol
+++ b/contracts/AttestationAutherSample.sol
@@ -49,6 +49,7 @@ contract AttestationAutherSample is
 
     error AttestationAutherSampleNoImageProvided();
     error AttestationAutherSampleInvalidAdmin();
+    error AttestationAutherSampleMismatchedLengths();
 
     function initialize(EnclaveImage[] memory images, address _admin) external initializer {
         if (!(images.length != 0)) revert AttestationAutherSampleNoImageProvided();
@@ -59,6 +60,20 @@ contract AttestationAutherSample is
         __AccessControl_init_unchained();
         __UUPSUpgradeable_init_unchained();
         __AttestationAuther_init_unchained(images);
+
+        _grantRole(DEFAULT_ADMIN_ROLE, _admin);
+    }
+
+    function initializeWithFamilies(EnclaveImage[] memory images, bytes32[] memory families, address _admin) external initializer {
+        if (!(images.length == families.length)) revert AttestationAutherSampleMismatchedLengths();
+        if (!(images.length != 0)) revert AttestationAutherSampleNoImageProvided();
+        if (!(_admin != address(0))) revert AttestationAutherSampleInvalidAdmin();
+
+        __Context_init_unchained();
+        __ERC165_init_unchained();
+        __AccessControl_init_unchained();
+        __UUPSUpgradeable_init_unchained();
+        __AttestationAuther_init_unchained(images, families);
 
         _grantRole(DEFAULT_ADMIN_ROLE, _admin);
     }

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -47,6 +47,7 @@ contract AttestationAutherUpgradeable is
     error AttestationAutherPCRsInvalid();
     error AttestationAutherImageNotWhitelisted();
     error AttestationAutherImageAlreadyWhitelisted();
+    error AttestationAutherImageNotInFamily();
     error AttestationAutherKeyNotVerified();
     error AttestationAutherKeyAlreadyVerified();
     error AttestationAutherAttestationTooOld();
@@ -163,6 +164,15 @@ contract AttestationAutherUpgradeable is
         bytes32 imageId = $.verifiedKeys[key];
         if (!(imageId != bytes32(0))) revert AttestationAutherKeyNotVerified();
         if (!($.whitelistedImages[imageId].PCR0.length != 0)) revert AttestationAutherImageNotWhitelisted();
+    }
+
+    function _allowOnlyVerifiedFamily(address key, bytes32 family) internal view {
+        AttestationAutherStorage storage $ = _getAttestationAutherStorage();
+
+        bytes32 imageId = $.verifiedKeys[key];
+        if (!(imageId != bytes32(0))) revert AttestationAutherKeyNotVerified();
+        if (!($.whitelistedImages[imageId].PCR0.length != 0)) revert AttestationAutherImageNotWhitelisted();
+        if (!($.imageFamilies[family][imageId])) revert AttestationAutherImageNotInFamily();
     }
 
     function getWhitelistedImage(bytes32 _imageId) external view returns (EnclaveImage memory) {

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -53,6 +53,7 @@ contract AttestationAutherUpgradeable is
 
     event EnclaveImageWhitelisted(bytes32 indexed imageId, bytes PCR0, bytes PCR1, bytes PCR2);
     event EnclaveImageRevoked(bytes32 indexed imageId);
+    event EnclaveImageAddedToFamily(bytes32 indexed imageId, bytes32 family);
     event EnclaveKeyWhitelisted(bytes indexed enclavePubKey, bytes32 indexed imageId);
     event EnclaveKeyRevoked(bytes indexed enclavePubKey);
     event EnclaveKeyVerified(bytes indexed enclavePubKey, bytes32 indexed imageId);
@@ -90,6 +91,13 @@ contract AttestationAutherUpgradeable is
 
         delete $.whitelistedImages[imageId];
         emit EnclaveImageRevoked(imageId);
+    }
+
+    function _addEnclaveImageToFamily(bytes32 imageId, bytes32 family) internal {
+        AttestationAutherStorage storage $ = _getAttestationAutherStorage();
+
+        $.imageFamilies[family][imageId] = true;
+        emit EnclaveImageAddedToFamily(imageId, family);
     }
 
     function _whitelistEnclaveKey(bytes memory enclavePubKey, bytes32 imageId) internal {

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -30,6 +30,7 @@ contract AttestationAutherUpgradeable is
     struct AttestationAutherStorage {
         mapping(bytes32 => EnclaveImage) whitelistedImages;
         mapping(address => bytes32) verifiedKeys;
+        mapping(bytes32 => mapping(bytes32 => bool)) imageFamilies;
     }
 
     // keccak256(abi.encode(uint256(keccak256("marlin.oyster.storage.AttestationAuther")) - 1)) & ~bytes32(uint256(0xff))

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -54,6 +54,7 @@ contract AttestationAutherUpgradeable is
     event EnclaveImageWhitelisted(bytes32 indexed imageId, bytes PCR0, bytes PCR1, bytes PCR2);
     event EnclaveImageRevoked(bytes32 indexed imageId);
     event EnclaveImageAddedToFamily(bytes32 indexed imageId, bytes32 family);
+    event EnclaveImageRemovedFromFamily(bytes32 indexed imageId, bytes32 family);
     event EnclaveKeyWhitelisted(bytes indexed enclavePubKey, bytes32 indexed imageId);
     event EnclaveKeyRevoked(bytes indexed enclavePubKey);
     event EnclaveKeyVerified(bytes indexed enclavePubKey, bytes32 indexed imageId);
@@ -98,6 +99,13 @@ contract AttestationAutherUpgradeable is
 
         $.imageFamilies[family][imageId] = true;
         emit EnclaveImageAddedToFamily(imageId, family);
+    }
+
+    function _removeEnclaveImageFromFamily(bytes32 imageId, bytes32 family) internal {
+        AttestationAutherStorage storage $ = _getAttestationAutherStorage();
+
+        $.imageFamilies[family][imageId] = false;
+        emit EnclaveImageRemovedFromFamily(imageId, family);
     }
 
     function _whitelistEnclaveKey(bytes memory enclavePubKey, bytes32 imageId) internal {

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -65,6 +65,13 @@ contract AttestationAutherUpgradeable is
         }
     }
 
+    function __AttestationAuther_init_unchained(EnclaveImage[] memory images, bytes32[] memory families) internal onlyInitializing {
+        for (uint256 i = 0; i < images.length; i++) {
+            bytes32 imageId = _whitelistEnclaveImage(images[i]);
+            _addEnclaveImageToFamily(imageId, families[i]);
+        }
+    }
+
     function _pubKeyToAddress(bytes memory pubKey) internal pure returns (address) {
         if (!(pubKey.length == 64)) revert AttestationAutherPubkeyLengthInvalid();
 

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -186,4 +186,10 @@ contract AttestationAutherUpgradeable is
 
         return $.verifiedKeys[_key];
     }
+
+    function isImageInFamily(bytes32 imageId, bytes32 family) external view returns (bool) {
+        AttestationAutherStorage storage $ = _getAttestationAutherStorage();
+
+        return $.imageFamilies[family][imageId];
+    }
 }


### PR DESCRIPTION
Enables verification against specific image families in the same contract.