### PR TITLE
Address based enclave key events and revocation

### DIFF
--- a/contracts/AttestationAuther.sol
+++ b/contracts/AttestationAuther.sol
@@ -184,10 +184,9 @@ contract AttestationAuther {
 
     /// @notice Revoke an enclave key.
     /// May emit a `EnclaveKeyRevoked` event.
-    /// @param enclavePubKey Enclave key to be revoked.
+    /// @param enclaveAddress Enclave whose key is to be revoked.
     /// @return true if the key was freshly revoked, false otherwise.
-    function _revokeEnclaveKey(bytes memory enclavePubKey) internal virtual returns (bool) {
-        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+    function _revokeEnclaveKey(address enclaveAddress) internal virtual returns (bool) {
         if (!(verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
         delete verifiedKeys[enclaveAddress];

--- a/contracts/AttestationAuther.sol
+++ b/contracts/AttestationAuther.sol
@@ -173,10 +173,10 @@ contract AttestationAuther {
     function _whitelistEnclaveKey(bytes memory enclavePubKey, bytes32 imageId) internal virtual returns (bool) {
         if (!(whitelistedImages[imageId].PCR0.length != 0)) revert AttestationAutherImageNotWhitelisted();
 
-        address enclaveKey = _pubKeyToAddress(enclavePubKey);
-        if (!(verifiedKeys[enclaveKey] == bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+        if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
-        verifiedKeys[enclaveKey] = imageId;
+        verifiedKeys[enclaveAddress] = imageId;
         emit EnclaveKeyWhitelisted(enclavePubKey, imageId);
 
         return true;
@@ -187,10 +187,10 @@ contract AttestationAuther {
     /// @param enclavePubKey Enclave key to be revoked.
     /// @return true if the key was freshly revoked, false otherwise.
     function _revokeEnclaveKey(bytes memory enclavePubKey) internal virtual returns (bool) {
-        address enclaveKey = _pubKeyToAddress(enclavePubKey);
-        if (!(verifiedKeys[enclaveKey] != bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+        if (!(verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
-        delete verifiedKeys[enclaveKey];
+        delete verifiedKeys[enclaveAddress];
         emit EnclaveKeyRevoked(enclavePubKey);
 
         return true;
@@ -212,10 +212,10 @@ contract AttestationAuther {
 
         ATTESTATION_VERIFIER.verify(signature, attestation);
 
-        address enclaveKey = _pubKeyToAddress(attestation.enclavePubKey);
-        if (!(verifiedKeys[enclaveKey] == bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(attestation.enclavePubKey);
+        if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
-        verifiedKeys[enclaveKey] = imageId;
+        verifiedKeys[enclaveAddress] = imageId;
         emit EnclaveKeyVerified(attestation.enclavePubKey, imageId);
 
         return true;

--- a/contracts/AttestationAuther.sol
+++ b/contracts/AttestationAuther.sol
@@ -57,12 +57,12 @@ contract AttestationAuther {
     event EnclaveImageAddedToFamily(bytes32 indexed imageId, bytes32 family);
     /// @notice Emitted when enclave image `imageId` is removed from `family`.
     event EnclaveImageRemovedFromFamily(bytes32 indexed imageId, bytes32 family);
-    /// @notice Emitted when enclave key `enclavePubKey` is whitelisted against enclave image `imageId`.
-    event EnclaveKeyWhitelisted(bytes indexed enclavePubKey, bytes32 indexed imageId);
-    /// @notice Emitted when enclave key `enclavePubKey` is revoked.
-    event EnclaveKeyRevoked(bytes indexed enclavePubKey);
-    /// @notice Emitted when enclave key `enclavePubKey` is verified against enclave image `imageId`.
-    event EnclaveKeyVerified(bytes indexed enclavePubKey, bytes32 indexed imageId);
+    /// @notice Emitted when enclave key `enclaveAddress` is whitelisted against enclave image `imageId`.
+    event EnclaveKeyWhitelisted(address indexed enclaveAddress, bytes32 indexed imageId, bytes enclavePubKey);
+    /// @notice Emitted when enclave key `enclaveAddress` is revoked.
+    event EnclaveKeyRevoked(address indexed enclaveAddress);
+    /// @notice Emitted when enclave key `enclaveAddress` is verified against enclave image `imageId`.
+    event EnclaveKeyVerified(address indexed enclaveAddress, bytes32 indexed imageId, bytes enclavePubKey);
 
     // constructors cannot be overloaded, avoid taking images or families entirely
     // constructors of inheriting contracts can set them up explicitly using the functions below
@@ -177,7 +177,7 @@ contract AttestationAuther {
         if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
         verifiedKeys[enclaveAddress] = imageId;
-        emit EnclaveKeyWhitelisted(enclavePubKey, imageId);
+        emit EnclaveKeyWhitelisted(enclaveAddress, imageId, enclavePubKey);
 
         return true;
     }
@@ -191,7 +191,7 @@ contract AttestationAuther {
         if (!(verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
         delete verifiedKeys[enclaveAddress];
-        emit EnclaveKeyRevoked(enclavePubKey);
+        emit EnclaveKeyRevoked(enclaveAddress);
 
         return true;
     }
@@ -216,7 +216,7 @@ contract AttestationAuther {
         if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
         verifiedKeys[enclaveAddress] = imageId;
-        emit EnclaveKeyVerified(attestation.enclavePubKey, imageId);
+        emit EnclaveKeyVerified(enclaveAddress, imageId, attestation.enclavePubKey);
 
         return true;
     }

--- a/contracts/AttestationAutherSample.sol
+++ b/contracts/AttestationAutherSample.sol
@@ -75,8 +75,8 @@ contract AttestationAutherSample is
         return _whitelistEnclaveKey(enclavePubKey, imageId);
     }
 
-    function revokeEnclaveKey(bytes memory enclavePubKey) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
-        return _revokeEnclaveKey(enclavePubKey);
+    function revokeEnclaveKey(address enclaveAddress) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
+        return _revokeEnclaveKey(enclaveAddress);
     }
 
     function addEnclaveImageToFamily(

--- a/contracts/AttestationAutherSampleUpgradeable.sol
+++ b/contracts/AttestationAutherSampleUpgradeable.sol
@@ -101,8 +101,8 @@ contract AttestationAutherSampleUpgradeable is
         return _whitelistEnclaveKey(enclavePubKey, imageId);
     }
 
-    function revokeEnclaveKey(bytes memory enclavePubKey) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
-        return _revokeEnclaveKey(enclavePubKey);
+    function revokeEnclaveKey(address enclaveAddress) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
+        return _revokeEnclaveKey(enclaveAddress);
     }
 
     function addEnclaveImageToFamily(

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -85,12 +85,12 @@ contract AttestationAutherUpgradeable is
     event EnclaveImageAddedToFamily(bytes32 indexed imageId, bytes32 family);
     /// @notice Emitted when enclave image `imageId` is removed from `family`.
     event EnclaveImageRemovedFromFamily(bytes32 indexed imageId, bytes32 family);
-    /// @notice Emitted when enclave key `enclavePubKey` is whitelisted against enclave image `imageId`.
-    event EnclaveKeyWhitelisted(bytes indexed enclavePubKey, bytes32 indexed imageId);
-    /// @notice Emitted when enclave key `enclavePubKey` is revoked.
-    event EnclaveKeyRevoked(bytes indexed enclavePubKey);
-    /// @notice Emitted when enclave key `enclavePubKey` is verified against enclave image `imageId`.
-    event EnclaveKeyVerified(bytes indexed enclavePubKey, bytes32 indexed imageId);
+    /// @notice Emitted when enclave key `enclaveAddress` is whitelisted against enclave image `imageId`.
+    event EnclaveKeyWhitelisted(address indexed enclaveAddress, bytes32 indexed imageId, bytes enclavePubKey);
+    /// @notice Emitted when enclave key `enclaveAddress` is revoked.
+    event EnclaveKeyRevoked(address indexed enclaveAddress);
+    /// @notice Emitted when enclave key `enclaveAddress` is verified against enclave image `imageId`.
+    event EnclaveKeyVerified(address indexed enclaveAddress, bytes32 indexed imageId, bytes enclavePubKey);
 
     /// @notice Initializes the contract by whitelisting the provided enclave images.
     /// @param images Enclave images to be whitelisted.
@@ -205,7 +205,7 @@ contract AttestationAutherUpgradeable is
         if (!($.verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
         $.verifiedKeys[enclaveAddress] = imageId;
-        emit EnclaveKeyWhitelisted(enclavePubKey, imageId);
+        emit EnclaveKeyWhitelisted(enclaveAddress, imageId, enclavePubKey);
 
         return true;
     }
@@ -221,7 +221,7 @@ contract AttestationAutherUpgradeable is
         if (!($.verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
         delete $.verifiedKeys[enclaveAddress];
-        emit EnclaveKeyRevoked(enclavePubKey);
+        emit EnclaveKeyRevoked(enclaveAddress);
 
         return true;
     }
@@ -248,7 +248,7 @@ contract AttestationAutherUpgradeable is
         if (!($.verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
         $.verifiedKeys[enclaveAddress] = imageId;
-        emit EnclaveKeyVerified(attestation.enclavePubKey, imageId);
+        emit EnclaveKeyVerified(enclaveAddress, imageId, attestation.enclavePubKey);
 
         return true;
     }

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -201,10 +201,10 @@ contract AttestationAutherUpgradeable is
 
         if (!($.whitelistedImages[imageId].PCR0.length != 0)) revert AttestationAutherImageNotWhitelisted();
 
-        address enclaveKey = _pubKeyToAddress(enclavePubKey);
-        if (!($.verifiedKeys[enclaveKey] == bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+        if (!($.verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
-        $.verifiedKeys[enclaveKey] = imageId;
+        $.verifiedKeys[enclaveAddress] = imageId;
         emit EnclaveKeyWhitelisted(enclavePubKey, imageId);
 
         return true;
@@ -217,10 +217,10 @@ contract AttestationAutherUpgradeable is
     function _revokeEnclaveKey(bytes memory enclavePubKey) internal virtual returns (bool) {
         AttestationAutherStorage storage $ = _getAttestationAutherStorage();
 
-        address enclaveKey = _pubKeyToAddress(enclavePubKey);
-        if (!($.verifiedKeys[enclaveKey] != bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+        if (!($.verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
-        delete $.verifiedKeys[enclaveKey];
+        delete $.verifiedKeys[enclaveAddress];
         emit EnclaveKeyRevoked(enclavePubKey);
 
         return true;
@@ -244,10 +244,10 @@ contract AttestationAutherUpgradeable is
 
         ATTESTATION_VERIFIER.verify(signature, attestation);
 
-        address enclaveKey = _pubKeyToAddress(attestation.enclavePubKey);
-        if (!($.verifiedKeys[enclaveKey] == bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(attestation.enclavePubKey);
+        if (!($.verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
-        $.verifiedKeys[enclaveKey] = imageId;
+        $.verifiedKeys[enclaveAddress] = imageId;
         emit EnclaveKeyVerified(attestation.enclavePubKey, imageId);
 
         return true;

--- a/contracts/AttestationAutherUpgradeable.sol
+++ b/contracts/AttestationAutherUpgradeable.sol
@@ -212,12 +212,11 @@ contract AttestationAutherUpgradeable is
 
     /// @notice Revoke an enclave key.
     /// May emit a `EnclaveKeyRevoked` event.
-    /// @param enclavePubKey Enclave key to be revoked.
+    /// @param enclaveAddress Enclave whose key is to be revoked.
     /// @return true if the key was freshly revoked, false otherwise.
-    function _revokeEnclaveKey(bytes memory enclavePubKey) internal virtual returns (bool) {
+    function _revokeEnclaveKey(address enclaveAddress) internal virtual returns (bool) {
         AttestationAutherStorage storage $ = _getAttestationAutherStorage();
 
-        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
         if (!($.verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
         delete $.verifiedKeys[enclaveAddress];

--- a/contracts/AttestationVerifier.sol
+++ b/contracts/AttestationVerifier.sol
@@ -146,8 +146,7 @@ contract AttestationVerifier is
         return true;
     }
 
-    function _revokeEnclaveKey(bytes memory enclavePubKey) internal returns (bool) {
-        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+    function _revokeEnclaveKey(address enclaveAddress) internal returns (bool) {
         if (!(verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
         delete verifiedKeys[enclaveAddress];
@@ -175,8 +174,8 @@ contract AttestationVerifier is
         return _whitelistEnclaveKey(enclavePubKey, imageId);
     }
 
-    function revokeEnclaveKey(bytes memory enclavePubKey) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
-        return _revokeEnclaveKey(enclavePubKey);
+    function revokeEnclaveKey(address enclaveAddress) external onlyRole(DEFAULT_ADMIN_ROLE) returns (bool) {
+        return _revokeEnclaveKey(enclaveAddress);
     }
 
     //-------------------------------- Admin methods end --------------------------------//

--- a/contracts/AttestationVerifier.sol
+++ b/contracts/AttestationVerifier.sol
@@ -188,7 +188,7 @@ contract AttestationVerifier is
 
     function _verifyEnclaveKey(
         bytes memory signature,
-        IAttestationVerifier.Attestation memory attestation
+        Attestation memory attestation
     ) internal returns (bool) {
         if (!(attestation.timestampInMilliseconds / 1000 > block.timestamp - MAX_AGE))
             revert AttestationVerifierAttestationTooOld();

--- a/contracts/AttestationVerifier.sol
+++ b/contracts/AttestationVerifier.sol
@@ -80,7 +80,7 @@ contract AttestationVerifier is
 
     // ImageId -> image details
     mapping(bytes32 => EnclaveImage) public whitelistedImages;
-    // enclaveKey -> ImageId
+    // enclaveAddress -> ImageId
     mapping(address => bytes32) public verifiedKeys;
 
     uint256[48] private __gap_1;
@@ -137,20 +137,20 @@ contract AttestationVerifier is
     function _whitelistEnclaveKey(bytes memory enclavePubKey, bytes32 imageId) internal returns (bool) {
         if (!(whitelistedImages[imageId].PCR0.length != 0)) revert AttestationVerifierImageNotWhitelisted();
 
-        address enclaveKey = _pubKeyToAddress(enclavePubKey);
-        if (!(verifiedKeys[enclaveKey] == bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+        if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
-        verifiedKeys[enclaveKey] = imageId;
+        verifiedKeys[enclaveAddress] = imageId;
         emit EnclaveKeyWhitelisted(enclavePubKey, imageId);
 
         return true;
     }
 
     function _revokeEnclaveKey(bytes memory enclavePubKey) internal returns (bool) {
-        address enclaveKey = _pubKeyToAddress(enclavePubKey);
-        if (!(verifiedKeys[enclaveKey] != bytes32(0))) return false;
+        address enclaveAddress = _pubKeyToAddress(enclavePubKey);
+        if (!(verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
-        delete verifiedKeys[enclaveKey];
+        delete verifiedKeys[enclaveAddress];
         emit EnclaveKeyRevoked(enclavePubKey);
 
         return true;
@@ -198,10 +198,10 @@ contract AttestationVerifier is
 
         _verify(signature, attestation);
 
-        address enclaveKey = pubKeyToAddress(attestation.enclavePubKey);
-        if (!(verifiedKeys[enclaveKey] == bytes32(0))) return false;
+        address enclaveAddress = pubKeyToAddress(attestation.enclavePubKey);
+        if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
-        verifiedKeys[enclaveKey] = imageId;
+        verifiedKeys[enclaveAddress] = imageId;
         emit EnclaveKeyVerified(attestation.enclavePubKey, imageId);
 
         return true;

--- a/contracts/AttestationVerifier.sol
+++ b/contracts/AttestationVerifier.sol
@@ -97,9 +97,9 @@ contract AttestationVerifier is
 
     event EnclaveImageWhitelisted(bytes32 indexed imageId, bytes PCR0, bytes PCR1, bytes PCR2);
     event EnclaveImageRevoked(bytes32 indexed imageId);
-    event EnclaveKeyWhitelisted(bytes indexed enclavePubKey, bytes32 indexed imageId);
-    event EnclaveKeyRevoked(bytes indexed enclavePubKey);
-    event EnclaveKeyVerified(bytes indexed enclavePubKey, bytes32 indexed imageId);
+    event EnclaveKeyWhitelisted(address indexed enclaveAddress, bytes32 indexed imageId, bytes enclavePubKey);
+    event EnclaveKeyRevoked(address indexed enclaveAddress);
+    event EnclaveKeyVerified(address indexed enclaveAddress, bytes32 indexed imageId, bytes enclavePubKey);
 
     function _pubKeyToAddress(bytes memory pubKey) internal pure returns (address) {
         if (!(pubKey.length == 64)) revert AttestationVerifierPubkeyLengthInvalid();
@@ -141,7 +141,7 @@ contract AttestationVerifier is
         if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
         verifiedKeys[enclaveAddress] = imageId;
-        emit EnclaveKeyWhitelisted(enclavePubKey, imageId);
+        emit EnclaveKeyWhitelisted(enclaveAddress, imageId, enclavePubKey);
 
         return true;
     }
@@ -151,7 +151,7 @@ contract AttestationVerifier is
         if (!(verifiedKeys[enclaveAddress] != bytes32(0))) return false;
 
         delete verifiedKeys[enclaveAddress];
-        emit EnclaveKeyRevoked(enclavePubKey);
+        emit EnclaveKeyRevoked(enclaveAddress);
 
         return true;
     }
@@ -202,7 +202,7 @@ contract AttestationVerifier is
         if (!(verifiedKeys[enclaveAddress] == bytes32(0))) return false;
 
         verifiedKeys[enclaveAddress] = imageId;
-        emit EnclaveKeyVerified(attestation.enclavePubKey, imageId);
+        emit EnclaveKeyVerified(enclaveAddress, imageId, attestation.enclavePubKey);
 
         return true;
     }

--- a/test/AttestationAutherSample.ts
+++ b/test/AttestationAutherSample.ts
@@ -404,7 +404,7 @@ describe("AttestationAutherSample - Whitelist enclave", function() {
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(ethers.ZeroHash);
 
 		await expect(attestationAutherSample.whitelistEnclaveKey(pubkeys[15], getImageId(image1)))
-			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(pubkeys[15], getImageId(image1));
+			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image1));
 	});
 
@@ -417,7 +417,7 @@ describe("AttestationAutherSample - Whitelist enclave", function() {
 
 		expect(await attestationAutherSample.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.true;
 		await expect(attestationAutherSample.whitelistEnclaveKey(pubkeys[15], getImageId(image1)))
-			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(pubkeys[15], getImageId(image1));
+			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image1));
 
 		expect(await attestationAutherSample.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.false;
@@ -448,22 +448,22 @@ describe("AttestationAutherSample - Revoke enclave", function() {
 	takeSnapshotBeforeAndAfterEveryTest(async () => { });
 
 	it("non admin cannot revoke enclave", async function() {
-		await expect(attestationAutherSample.connect(signers[1]).revokeEnclaveKey(pubkeys[14])).to.be.revertedWithCustomError(attestationAutherSample, "AccessControlUnauthorizedAccount");
+		await expect(attestationAutherSample.connect(signers[1]).revokeEnclaveKey(addrs[14])).to.be.revertedWithCustomError(attestationAutherSample, "AccessControlUnauthorizedAccount");
 	});
 
 	it("admin can revoke enclave", async function() {
 		await attestationAutherSample.whitelistEnclaveKey(pubkeys[14], getImageId(image2));
 		expect(await attestationAutherSample.getVerifiedKey(addrs[14])).to.equal(getImageId(image2));
 
-		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(pubkeys[14])).to.be.true;
-		await expect(attestationAutherSample.revokeEnclaveKey(pubkeys[14]))
-			.to.emit(attestationAutherSample, "EnclaveKeyRevoked").withArgs(pubkeys[14]);
+		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(addrs[14])).to.be.true;
+		await expect(attestationAutherSample.revokeEnclaveKey(addrs[14]))
+			.to.emit(attestationAutherSample, "EnclaveKeyRevoked").withArgs(addrs[14]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[14])).to.equal(ethers.ZeroHash);
 	});
 
 	it("admin can revoke unwhitelisted enclave", async function() {
-		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(pubkeys[15])).to.be.false;
-		await expect(attestationAutherSample.revokeEnclaveKey(pubkeys[14]))
+		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(addrs[15])).to.be.false;
+		await expect(attestationAutherSample.revokeEnclaveKey(addrs[14]))
 			.to.not.emit(attestationAutherSample, "EnclaveKeyRevoked");
 	});
 });
@@ -503,7 +503,7 @@ describe("AttestationAutherSample - Verify enclave key", function() {
 
 		expect(await attestationAutherSample.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.true;
 		await expect(attestationAutherSample.connect(signers[1]).verifyEnclaveKey(signature, attestation))
-			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(pubkeys[15], getImageId(image3));
+			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(addrs[15], getImageId(image3), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image3));
 	});
 
@@ -555,7 +555,7 @@ describe("AttestationAutherSample - Verify enclave key", function() {
 
 		expect(await attestationAutherSample.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.true;
 		await expect(attestationAutherSample.connect(signers[1]).verifyEnclaveKey(signature, attestation))
-			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(pubkeys[15], getImageId(image3));
+			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(addrs[15], getImageId(image3), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image3));
 
 		expect(await attestationAutherSample.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.false;
@@ -575,7 +575,7 @@ describe("AttestationAutherSample - Verify enclave key", function() {
 		const timestamp = await time.latest() * 1000;
 		let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], timestamp - 540000);
 
-		await attestationVerifier.revokeEnclaveKey(pubkeys[14]);
+		await attestationVerifier.revokeEnclaveKey(addrs[14]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verifyEnclaveKey(signature, attestation))
 			.to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
@@ -661,7 +661,7 @@ describe("AttestationAutherSample - Safe verify with params", function() {
 	it("cannot verify with revoked key", async function() {
 		let signature = await createSignature("testmsg", wallets[15]);
 
-		await attestationAutherSample.revokeEnclaveKey(pubkeys[15]);
+		await attestationAutherSample.revokeEnclaveKey(addrs[15]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verify(
 			signature, "testmsg",
@@ -738,7 +738,7 @@ describe("AttestationAutherSample - Verify with family", function() {
 	it("cannot verify with revoked key", async function() {
 		let signature = await createSignature("testmsg", wallets[15]);
 
-		await attestationAutherSample.revokeEnclaveKey(pubkeys[15]);
+		await attestationAutherSample.revokeEnclaveKey(addrs[15]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verify(
 			signature, "testmsg",
@@ -780,7 +780,7 @@ describe("AttestationAutherSample - Verify with family", function() {
 	it("cannot verify family with revoked key", async function() {
 		let signature = await createSignature("testmsg", wallets[15]);
 
-		await attestationAutherSample.revokeEnclaveKey(pubkeys[15]);
+		await attestationAutherSample.revokeEnclaveKey(addrs[15]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verifyFamily(
 			signature, "testmsg", THIRD_FAMILY,

--- a/test/AttestationAutherSampleUpgradeable.ts
+++ b/test/AttestationAutherSampleUpgradeable.ts
@@ -523,7 +523,7 @@ describe("AttestationAutherSampleUpgradeable - Whitelist enclave", function() {
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(ethers.ZeroHash);
 
 		await expect(attestationAutherSample.whitelistEnclaveKey(pubkeys[15], getImageId(image1)))
-			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(pubkeys[15], getImageId(image1));
+			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image1));
 	});
 
@@ -536,7 +536,7 @@ describe("AttestationAutherSampleUpgradeable - Whitelist enclave", function() {
 
 		expect(await attestationAutherSample.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.true;
 		await expect(attestationAutherSample.whitelistEnclaveKey(pubkeys[15], getImageId(image1)))
-			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(pubkeys[15], getImageId(image1));
+			.to.emit(attestationAutherSample, "EnclaveKeyWhitelisted").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image1));
 
 		expect(await attestationAutherSample.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.false;
@@ -570,22 +570,22 @@ describe("AttestationAutherSampleUpgradeable - Revoke enclave", function() {
 	takeSnapshotBeforeAndAfterEveryTest(async () => { });
 
 	it("non admin cannot revoke enclave", async function() {
-		await expect(attestationAutherSample.connect(signers[1]).revokeEnclaveKey(pubkeys[14])).to.be.revertedWithCustomError(attestationAutherSample, "AccessControlUnauthorizedAccount");
+		await expect(attestationAutherSample.connect(signers[1]).revokeEnclaveKey(addrs[14])).to.be.revertedWithCustomError(attestationAutherSample, "AccessControlUnauthorizedAccount");
 	});
 
 	it("admin can revoke enclave", async function() {
 		await attestationAutherSample.whitelistEnclaveKey(pubkeys[14], getImageId(image2));
 		expect(await attestationAutherSample.getVerifiedKey(addrs[14])).to.equal(getImageId(image2));
 
-		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(pubkeys[14])).to.be.true;
-		await expect(attestationAutherSample.revokeEnclaveKey(pubkeys[14]))
-			.to.emit(attestationAutherSample, "EnclaveKeyRevoked").withArgs(pubkeys[14]);
+		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(addrs[14])).to.be.true;
+		await expect(attestationAutherSample.revokeEnclaveKey(addrs[14]))
+			.to.emit(attestationAutherSample, "EnclaveKeyRevoked").withArgs(addrs[14]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[14])).to.equal(ethers.ZeroHash);
 	});
 
 	it("admin can revoke unwhitelisted enclave", async function() {
-		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(pubkeys[15])).to.be.false;
-		await expect(attestationAutherSample.revokeEnclaveKey(pubkeys[14]))
+		expect(await attestationAutherSample.revokeEnclaveKey.staticCall(addrs[15])).to.be.false;
+		await expect(attestationAutherSample.revokeEnclaveKey(addrs[14]))
 			.to.not.emit(attestationAutherSample, "EnclaveKeyRevoked");
 	});
 });
@@ -628,7 +628,7 @@ describe("AttestationAutherSampleUpgradeable - Verify enclave key", function() {
 
 		expect(await attestationAutherSample.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.true;
 		await expect(attestationAutherSample.connect(signers[1]).verifyEnclaveKey(signature, attestation))
-			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(pubkeys[15], getImageId(image3));
+			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(addrs[15], getImageId(image3), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image3));
 	});
 
@@ -680,7 +680,7 @@ describe("AttestationAutherSampleUpgradeable - Verify enclave key", function() {
 
 		expect(await attestationAutherSample.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.true;
 		await expect(attestationAutherSample.connect(signers[1]).verifyEnclaveKey(signature, attestation))
-			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(pubkeys[15], getImageId(image3));
+			.to.emit(attestationAutherSample, "EnclaveKeyVerified").withArgs(addrs[15], getImageId(image3), pubkeys[15]);
 		expect(await attestationAutherSample.getVerifiedKey(addrs[15])).to.equal(getImageId(image3));
 
 		expect(await attestationAutherSample.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.false;
@@ -700,7 +700,7 @@ describe("AttestationAutherSampleUpgradeable - Verify enclave key", function() {
 		const timestamp = await time.latest() * 1000;
 		let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], timestamp - 540000);
 
-		await attestationVerifier.revokeEnclaveKey(pubkeys[14]);
+		await attestationVerifier.revokeEnclaveKey(addrs[14]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verifyEnclaveKey(signature, attestation))
 			.to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
@@ -789,7 +789,7 @@ describe("AttestationAutherSampleUpgradeable - Safe verify with params", functio
 	it("cannot verify with revoked key", async function() {
 		let signature = await createSignature("testmsg", wallets[15]);
 
-		await attestationAutherSample.revokeEnclaveKey(pubkeys[15]);
+		await attestationAutherSample.revokeEnclaveKey(addrs[15]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verify(
 			signature, "testmsg",
@@ -869,7 +869,7 @@ describe("AttestationAutherSampleUpgradeable - Verify with family", function() {
 	it("cannot verify with revoked key", async function() {
 		let signature = await createSignature("testmsg", wallets[15]);
 
-		await attestationAutherSample.revokeEnclaveKey(pubkeys[15]);
+		await attestationAutherSample.revokeEnclaveKey(addrs[15]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verify(
 			signature, "testmsg",
@@ -911,7 +911,7 @@ describe("AttestationAutherSampleUpgradeable - Verify with family", function() {
 	it("cannot verify family with revoked key", async function() {
 		let signature = await createSignature("testmsg", wallets[15]);
 
-		await attestationAutherSample.revokeEnclaveKey(pubkeys[15]);
+		await attestationAutherSample.revokeEnclaveKey(addrs[15]);
 
 		await expect(attestationAutherSample.connect(signers[1]).verifyFamily(
 			signature, "testmsg", THIRD_FAMILY,

--- a/test/AttestationVerifier.ts
+++ b/test/AttestationVerifier.ts
@@ -215,7 +215,7 @@ testAdminRole("AttestationVerifier - Admin", async function(signers: Signer[], a
     return attestationVerifier;
 });
 
-describe("AttestationVerifier - Whitelist image", function() {
+describe("AttestationVerifier - Whitelist enclave image", function() {
     let signers: Signer[];
     let addrs: string[];
     let wallets: Wallet[];
@@ -239,11 +239,11 @@ describe("AttestationVerifier - Whitelist image", function() {
 
     takeSnapshotBeforeAndAfterEveryTest(async () => { });
 
-    it("non admin cannot whitelist image", async function() {
+    it("non admin cannot whitelist enclave image", async function() {
         await expect(attestationVerifier.connect(signers[1]).whitelistEnclaveImage(image3.PCR0, image3.PCR1, image3.PCR2)).to.be.revertedWithCustomError(attestationVerifier, "AccessControlUnauthorizedAccount");
     });
 
-    it("admin can whitelist image", async function() {
+    it("admin can whitelist enclave image", async function() {
         {
             const { PCR0, PCR1, PCR2 } = await attestationVerifier.whitelistedImages(getImageId(image3));
             expect([PCR0, PCR1, PCR2]).to.deep.equal(["0x", "0x", "0x"]);
@@ -258,17 +258,17 @@ describe("AttestationVerifier - Whitelist image", function() {
         }
     });
 
-    it("admin cannot whitelist image with empty PCRs", async function() {
+    it("admin cannot whitelist enclave image with empty PCRs", async function() {
         await expect(attestationVerifier.whitelistEnclaveImage("0x", "0x", "0x")).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierPCRsInvalid");
     });
 
-    it("admin cannot whitelist image with invalid PCRs", async function() {
+    it("admin cannot whitelist enclave image with invalid PCRs", async function() {
         await expect(attestationVerifier.whitelistEnclaveImage("0x1111111111", image3.PCR1, image3.PCR2)).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierPCRsInvalid");
         await expect(attestationVerifier.whitelistEnclaveImage(image3.PCR0, "0x1111111111", image3.PCR2)).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierPCRsInvalid");
         await expect(attestationVerifier.whitelistEnclaveImage(image3.PCR0, image3.PCR1, "0x1111111111")).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierPCRsInvalid");
     });
 
-    it("admin can rewhitelist image", async function() {
+    it("admin can rewhitelist enclave image", async function() {
         expect(await attestationVerifier.whitelistEnclaveImage.staticCall(image3.PCR0, image3.PCR1, image3.PCR2)).to.deep.equal([getImageId(image3), true]);
         await expect(attestationVerifier.whitelistEnclaveImage(image3.PCR0, image3.PCR1, image3.PCR2))
             .to.emit(attestationVerifier, "EnclaveImageWhitelisted").withArgs(getImageId(image3), image3.PCR0, image3.PCR1, image3.PCR2);
@@ -283,7 +283,7 @@ describe("AttestationVerifier - Whitelist image", function() {
     });
 });
 
-describe("AttestationVerifier - Revoke image", function() {
+describe("AttestationVerifier - Revoke enclave image", function() {
     let signers: Signer[];
     let addrs: string[];
     let wallets: Wallet[];
@@ -307,11 +307,11 @@ describe("AttestationVerifier - Revoke image", function() {
 
     takeSnapshotBeforeAndAfterEveryTest(async () => { });
 
-    it("non admin cannot revoke image", async function() {
+    it("non admin cannot revoke enclave image", async function() {
         await expect(attestationVerifier.connect(signers[1]).revokeEnclaveImage(getImageId(image1))).to.be.revertedWithCustomError(attestationVerifier, "AccessControlUnauthorizedAccount");
     });
 
-    it("admin can revoke image", async function() {
+    it("admin can revoke enclave image", async function() {
         {
             const { PCR0, PCR1, PCR2 } = await attestationVerifier.whitelistedImages(getImageId(image1));
             expect({ PCR0, PCR1, PCR2 }).to.deep.equal(image1);
@@ -326,14 +326,14 @@ describe("AttestationVerifier - Revoke image", function() {
         }
     });
 
-    it("admin can revoke unwhitelisted image", async function() {
+    it("admin can revoke unwhitelisted enclave image", async function() {
         expect(await attestationVerifier.revokeEnclaveImage.staticCall(getImageId(image3))).to.be.false;
         await expect(attestationVerifier.revokeEnclaveImage(getImageId(image3)))
             .to.not.emit(attestationVerifier, "EnclaveImageRevoked");
     });
 });
 
-describe("AttestationVerifier - Whitelist enclave", function() {
+describe("AttestationVerifier - Whitelist enclave key", function() {
     let signers: Signer[];
     let addrs: string[];
     let wallets: Wallet[];
@@ -357,29 +357,29 @@ describe("AttestationVerifier - Whitelist enclave", function() {
 
     takeSnapshotBeforeAndAfterEveryTest(async () => { });
 
-    it("non admin cannot whitelist enclave", async function() {
+    it("non admin cannot whitelist enclave key", async function() {
         await expect(attestationVerifier.connect(signers[1]).whitelistEnclaveKey(pubkeys[15], getImageId(image1))).to.be.revertedWithCustomError(attestationVerifier, "AccessControlUnauthorizedAccount");
     });
 
-    it("admin can whitelist enclave", async function() {
+    it("admin can whitelist enclave key", async function() {
         expect(await attestationVerifier.verifiedKeys(addrs[15])).to.equal(ethers.ZeroHash);
 
         expect(await attestationVerifier.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.true;
         await expect(attestationVerifier.whitelistEnclaveKey(pubkeys[15], getImageId(image1)))
-            .to.emit(attestationVerifier, "EnclaveKeyWhitelisted").withArgs(pubkeys[15], getImageId(image1));
+            .to.emit(attestationVerifier, "EnclaveKeyWhitelisted").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
         expect(await attestationVerifier.verifiedKeys(addrs[15])).to.equal(getImageId(image1));
     });
 
-    it("admin cannot whitelist enclave with unwhitelisted image", async function() {
+    it("admin cannot whitelist enclave key with unwhitelisted enclave image", async function() {
         await expect(attestationVerifier.whitelistEnclaveKey(pubkeys[15], getImageId(image3))).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierImageNotWhitelisted");
     });
 
-    it("admin can rewhitelist enclave", async function() {
+    it("admin can rewhitelist enclave key", async function() {
         expect(await attestationVerifier.verifiedKeys(addrs[15])).to.equal(ethers.ZeroHash);
 
         expect(await attestationVerifier.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.true;
         await expect(attestationVerifier.whitelistEnclaveKey(pubkeys[15], getImageId(image1)))
-            .to.emit(attestationVerifier, "EnclaveKeyWhitelisted").withArgs(pubkeys[15], getImageId(image1));
+            .to.emit(attestationVerifier, "EnclaveKeyWhitelisted").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
         expect(await attestationVerifier.verifiedKeys(addrs[15])).to.equal(getImageId(image1));
 
         expect(await attestationVerifier.whitelistEnclaveKey.staticCall(pubkeys[15], getImageId(image1))).to.be.false;
@@ -388,7 +388,7 @@ describe("AttestationVerifier - Whitelist enclave", function() {
     });
 });
 
-describe("AttestationVerifier - Revoke enclave", function() {
+describe("AttestationVerifier - Revoke enclave key", function() {
     let signers: Signer[];
     let addrs: string[];
     let wallets: Wallet[];
@@ -412,22 +412,22 @@ describe("AttestationVerifier - Revoke enclave", function() {
 
     takeSnapshotBeforeAndAfterEveryTest(async () => { });
 
-    it("non admin cannot revoke enclave", async function() {
-        await expect(attestationVerifier.connect(signers[1]).revokeEnclaveKey(pubkeys[14])).to.be.revertedWithCustomError(attestationVerifier, "AccessControlUnauthorizedAccount");
+    it("non admin cannot revoke enclave key", async function() {
+        await expect(attestationVerifier.connect(signers[1]).revokeEnclaveKey(addrs[14])).to.be.revertedWithCustomError(attestationVerifier, "AccessControlUnauthorizedAccount");
     });
 
-    it("admin can revoke enclave", async function() {
+    it("admin can revoke enclave key", async function() {
         expect(await attestationVerifier.verifiedKeys(addrs[14])).to.equal(getImageId(image2));
 
-        expect(await attestationVerifier.revokeEnclaveKey.staticCall(pubkeys[14])).to.be.true;
-        await expect(attestationVerifier.revokeEnclaveKey(pubkeys[14]))
-            .to.emit(attestationVerifier, "EnclaveKeyRevoked").withArgs(pubkeys[14]);
+        expect(await attestationVerifier.revokeEnclaveKey.staticCall(addrs[14])).to.be.true;
+        await expect(attestationVerifier.revokeEnclaveKey(addrs[14]))
+            .to.emit(attestationVerifier, "EnclaveKeyRevoked").withArgs(addrs[14]);
         expect(await attestationVerifier.verifiedKeys(addrs[14])).to.equal(ethers.ZeroHash);
     });
 
-    it("admin cannot revoke unwhitelisted enclave", async function() {
-        expect(await attestationVerifier.revokeEnclaveKey.staticCall(pubkeys[15])).to.be.false;
-        await expect(attestationVerifier.revokeEnclaveKey(pubkeys[15]))
+    it("admin cannot revoke unwhitelisted enclave key", async function() {
+        expect(await attestationVerifier.revokeEnclaveKey.staticCall(addrs[15])).to.be.false;
+        await expect(attestationVerifier.revokeEnclaveKey(addrs[15]))
             .to.not.emit(attestationVerifier, "EnclaveKeyRevoked");
     });
 });
@@ -462,7 +462,7 @@ describe("AttestationVerifier - Verify enclave key", function() {
 
         expect(await attestationVerifier.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.true;
         await expect(attestationVerifier.connect(signers[1]).verifyEnclaveKey(signature, attestation))
-            .to.emit(attestationVerifier, "EnclaveKeyVerified").withArgs(pubkeys[15], getImageId(image1));
+            .to.emit(attestationVerifier, "EnclaveKeyVerified").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
         expect(await attestationVerifier.verifiedKeys(addrs[15])).to.equal(getImageId(image1));
     });
 
@@ -500,7 +500,7 @@ describe("AttestationVerifier - Verify enclave key", function() {
             .to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierPubkeyLengthInvalid");
     });
 
-    it("cannot verify enclave key with unwhitelisted image", async function() {
+    it("cannot verify enclave key with unwhitelisted enclave image", async function() {
         const timestamp = await time.latest() * 1000;
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], timestamp - 240000);
 
@@ -514,7 +514,7 @@ describe("AttestationVerifier - Verify enclave key", function() {
 
         expect(await attestationVerifier.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.true;
         await expect(attestationVerifier.connect(signers[1]).verifyEnclaveKey(signature, attestation))
-            .to.emit(attestationVerifier, "EnclaveKeyVerified").withArgs(pubkeys[15], getImageId(image1));
+            .to.emit(attestationVerifier, "EnclaveKeyVerified").withArgs(addrs[15], getImageId(image1), pubkeys[15]);
         expect(await attestationVerifier.verifiedKeys(addrs[15])).to.equal(getImageId(image1));
 
         expect(await attestationVerifier.connect(signers[1]).verifyEnclaveKey.staticCall(signature, attestation)).to.be.false;
@@ -522,7 +522,7 @@ describe("AttestationVerifier - Verify enclave key", function() {
             .to.not.emit(attestationVerifier, "EnclaveKeyVerified");
     });
 
-    it("cannot verify enclave key with unwhitelisted key", async function() {
+    it("cannot verify enclave key with unwhitelisted enclave key", async function() {
         const timestamp = await time.latest() * 1000;
         let [signature, attestation] = await createAttestation(pubkeys[15], image1, wallets[16], timestamp - 240000);
 
@@ -530,17 +530,17 @@ describe("AttestationVerifier - Verify enclave key", function() {
             .to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify enclave key with revoked key", async function() {
+    it("cannot verify enclave key with revoked enclave key", async function() {
         const timestamp = await time.latest() * 1000;
         let [signature, attestation] = await createAttestation(pubkeys[15], image1, wallets[14], timestamp - 240000);
 
-        await attestationVerifier.revokeEnclaveKey(pubkeys[14]);
+        await attestationVerifier.revokeEnclaveKey(addrs[14]);
 
         await expect(attestationVerifier.connect(signers[1]).verifyEnclaveKey(signature, attestation))
             .to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify enclave key with revoked image", async function() {
+    it("cannot verify enclave key with revoked enclave image", async function() {
         const timestamp = await time.latest() * 1000;
         let [signature, attestation] = await createAttestation(pubkeys[15], image1, wallets[14], timestamp - 240000);
 
@@ -551,7 +551,7 @@ describe("AttestationVerifier - Verify enclave key", function() {
     });
 });
 
-describe("AttestationVerifier - Safe verify with params", function() {
+describe("AttestationVerifier - Verify with params", function() {
     let signers: Signer[];
     let addrs: string[];
     let wallets: Wallet[];
@@ -606,7 +606,7 @@ describe("AttestationVerifier - Safe verify with params", function() {
         )).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify with unwhitelisted key", async function() {
+    it("cannot verify with unwhitelisted enclave key", async function() {
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[16], 300000);
 
         await expect(attestationVerifier.connect(signers[1])['verify(bytes,(bytes,bytes,bytes,bytes,uint256))'](
@@ -614,17 +614,17 @@ describe("AttestationVerifier - Safe verify with params", function() {
         )).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify with revoked key", async function() {
+    it("cannot verify with revoked enclave key", async function() {
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], 300000);
 
-        await attestationVerifier.revokeEnclaveKey(pubkeys[14]);
+        await attestationVerifier.revokeEnclaveKey(addrs[14]);
 
         await expect(attestationVerifier.connect(signers[1])['verify(bytes,(bytes,bytes,bytes,bytes,uint256))'](
             signature, attestation,
         )).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify with revoked image", async function() {
+    it("cannot verify with revoked enclave image", async function() {
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], 300000);
 
         await attestationVerifier.revokeEnclaveImage(getImageId(image2));
@@ -635,7 +635,7 @@ describe("AttestationVerifier - Safe verify with params", function() {
     });
 });
 
-describe("AttestationVerifier - Safe verify with bytes", function() {
+describe("AttestationVerifier - Verify with bytes", function() {
     let signers: Signer[];
     let addrs: string[];
     let wallets: Wallet[];
@@ -711,7 +711,7 @@ describe("AttestationVerifier - Safe verify with bytes", function() {
         )).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify with unwhitelisted key", async function() {
+    it("cannot verify with unwhitelisted enclave key", async function() {
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[16], 300000);
 
         await expect(attestationVerifier.connect(signers[1])['verify(bytes)'](
@@ -722,10 +722,10 @@ describe("AttestationVerifier - Safe verify with bytes", function() {
         )).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify with revoked key", async function() {
+    it("cannot verify with revoked enclave key", async function() {
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], 300000);
 
-        await attestationVerifier.revokeEnclaveKey(pubkeys[14]);
+        await attestationVerifier.revokeEnclaveKey(addrs[14]);
 
         await expect(attestationVerifier.connect(signers[1])['verify(bytes)'](
             ethers.AbiCoder.defaultAbiCoder().encode(
@@ -735,7 +735,7 @@ describe("AttestationVerifier - Safe verify with bytes", function() {
         )).to.be.revertedWithCustomError(attestationVerifier, "AttestationVerifierKeyNotVerified");
     });
 
-    it("cannot verify with revoked image", async function() {
+    it("cannot verify with revoked enclave image", async function() {
         let [signature, attestation] = await createAttestation(pubkeys[15], image3, wallets[14], 300000);
 
         await attestationVerifier.revokeEnclaveImage(getImageId(image2));


### PR DESCRIPTION
There's an interesting contradiction which came up during serverless development. The attestation verifier does not store public keys, nor does the auther, mainly for efficiency. By extension, we can expect other contracts to not store public keys either, especially if they don't care about the additional capabilities. How do we expect them to call `_revokeEnclave` then? The concrete use case in serverless is when slashing occurs and a node needs to be kicked out. Can assume similar requirements for voluntary exits as well.

One thing to consider is whether calling `_revokeEnclave` is an anti-pattern that should never really happen, an enclave key once verified can be considered verified forever. The only remaining argument in this case is keeping storage "clean" which is admittedly a little weak.

In this PR, the "identity" of an enclave is its address that is indexed in events while revoke functions work based on address instead of public key.

AFAIK, the only reason we even have the public key is so off-chain applications can use it to send encrypted messages to the enclave. The current mechanism is by querying/indexing events to figure out the public key and this is still possible with these changes since the Whitelist and Verify events retain the public key as an additional parameter.